### PR TITLE
042240

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,9 +3,10 @@
 from trytond.pool import Pool
 from . import account
 from . import currency
-from . import tax
 from . import invoice
+from . import party
 from . import product
+from . import tax
 
 
 def register():
@@ -17,14 +18,15 @@ def register():
         account.AccountType,
         account.AccountTypeTemplate,
         currency.Currency,
+        invoice.Invoice,
+        invoice.InvoiceLine,
+        party.PartyIdentifier,
+        product.Category,
+        product.CategoryAccount,
+        product.Template,
         tax.TaxCodeTemplate,
         tax.TaxTemplate,
         tax.Tax,
         tax.TaxRuleTemplate,
         tax.TaxRuleLineTemplate,
-        invoice.Invoice,
-        invoice.InvoiceLine,
-        product.Category,
-        product.CategoryAccount,
-        product.Template,
         module='account_es', type_='model')

--- a/party.py
+++ b/party.py
@@ -1,0 +1,24 @@
+# This file is part of Tryton.  The COPYRIGHT file at the top level of
+# this repository contains the full copyright notices and license terms.
+from trytond.model import fields
+from trytond.pool import PoolMeta
+
+
+class PartyIdentifier(metaclass=PoolMeta):
+    __name__ = 'party.identifier'
+
+    @classmethod
+    def default_type(cls):
+        return 'eu_vat'
+
+    def es_country(self):
+        if self.type == 'eu_vat':
+            return self.code[:2]
+        if self.type in {'es_cif', 'es_dni', 'es_nie', 'es_nif'}:
+            return 'ES'
+
+    def es_code(self):
+        if self.type == 'eu_vat':
+            return self.code[2:11]
+        if self.type in {'es_cif', 'es_dni', 'es_nie', 'es_nif'}:
+            return self.code[:9]


### PR DESCRIPTION
Adding 2 new functions used, by the moment, for the aeat_347 module, to take Spanish CIF/NIF from tax identifier, and tahe country code.

This functions are taken from account_es core module. Added for the possible future migration to that module.